### PR TITLE
Fix #23 - Crash while deleting zero projects

### DIFF
--- a/tui/projectui/model.go
+++ b/tui/projectui/model.go
@@ -123,7 +123,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.input.Focus()
 				cmd = textinput.Blink
 			case key.Matches(msg, constants.Keymap.Delete):
-				cmd = deleteProjectCmd(m.getActiveProjectID(), m.pr)
+				items := m.list.Items()
+				if len(items) > 0 {
+					cmd = deleteProjectCmd(m.getActiveProjectID(), m.pr)
+				}
 			default:
 				m.list, cmd = m.list.Update(msg)
 			}


### PR DESCRIPTION
Fix to issue #23 of the app crashing while deleting zero projects.

Now it does a simple check before getting the active project ID which is then passed to the delete project command.

The check is simple the number of Items currently. If more than 0, go ahead and delete. If not, skip that code.

Comments are welcome. Thanks