### PR TITLE
Fix RenameProject method signature in Project Repository interface

### DIFF
--- a/project/project.go
+++ b/project/project.go
@@ -107,9 +107,9 @@ func (g *GormRepository) DeleteProject(projectID uint) error {
 }
 
 // RenameProject rename an existing project
-func (g *GormRepository) RenameProject(id uint, name string) error {
+func (g *GormRepository) RenameProject(projectID uint, name string) error {
 	var newProject Project
-	if err := g.DB.Where("id = ?", id).First(&newProject).Error; err != nil {
+	if err := g.DB.Where("id = ?", projectID).First(&newProject).Error; err != nil {
 		return fmt.Errorf("Unable to rename project: %w", err)
 	}
 	newProject.Name = name

--- a/project/project.go
+++ b/project/project.go
@@ -44,7 +44,7 @@ type Repository interface {
 	GetAllProjects() ([]Project, error)
 	CreateProject(name string) (Project, error)
 	DeleteProject(projectID uint) error
-	RenameProject(projectID uint) error
+	RenameProject(projectID uint, name string) error
 }
 
 // GormRepository holds the gorm DB and is a ProjectRepository


### PR DESCRIPTION
This PR addresses an inconsistency between the `Repository` interface and the `GormRepository` implementation.

#### Changes:
- Renamed `id` to `projectID` in `GormRepository`'s `RenameProject` method.
- Changed `RenameProject` in `Repository` interface from `RenameProject(projectID uint) error` to `RenameProject(projectID uint, name string) error`.

The method in the `GormRepository` struct was designed to take two arguments (`id` and `name`), while the `Repository` interface defined it to take only one (`projectID`). Although this didn't prevent functionality, it created inconsistency between the interface and implementation. Updating the interface makes them consistent, improving overall code readability and maintainability.